### PR TITLE
fix: Fixes type Field cannot be used in for loop error

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,13 @@ Before you can use this implementation, ensure you have the Noir language and it
 Once you have Noir set up, clone this repository to your local machine:
 
 ```bash
-git clone https://github.com/yourusername/mimc-sponge-noir.git
+git clone https://github.com/KumaCrypto/mimc_sponge_noir.git
 cd mimc-sponge-noir
+```
+
+To import this as a dependency in your noir project, please add this to your nargo`[dependencies]`. Replace the tag with the version you wish to use.
+```
+mimc_sponge = { tag = "v0.0.2", git = "https://github.com/KumaCrypto/mimc_sponge_noir" }
 ```
 
 ## Disclaimer

--- a/src/lib.nr
+++ b/src/lib.nr
@@ -6,9 +6,9 @@ use constants::get_c_partial;
 
 // log_5(21888242871839275222246405745257275088548364400416034343698204186575808495617) ~= 110
 // => nRounds should be 220
-global nRounds: Field = 220;
+global nRounds: u64 = 220;
 
-pub fn mimc_sponge<N, M>(ins: [Field; N], k: Field) -> [Field; M] {
+pub fn mimc_sponge<let N: u32, let M: u32>(ins: [Field; N], k: Field) -> [Field; M] {
     let mut S = MiMCFeistel(ins[0], 0, k); // First round with xL = ins[0] and xR = 0
 
     for i in 1..N {


### PR DESCRIPTION
Fixes #1 

Tweaked the type of `nRounds`, which should fix the issue. Also specified datatypes for the generics, and added a README update to import the package.
